### PR TITLE
Don't evaluate all attrs passed into mkSearchData

### DIFF
--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -18,15 +18,14 @@ rec {
 
   mkSearchData = scopes:
     let
-      optionsJSON = opt: opt.optionsJSON or (mkOptionsJSON {
-        inherit (opt) modules;
-        specialArgs = opt.specialArgs or { };
-      });
-      config = {
-        scopes = map
-          (scope: (lib.filterAttrs (name: _value: name != "modules") scope) // { optionsJson = optionsJSON scope; })
-          scopes;
-      };
+      config.scopes = map (scope: {
+        inherit (scope) urlPrefix;
+      } // lib.optionalAttrs (scope?name) { inherit (scope) name; } // {
+        optionsJson = scope.optionsJSON or (mkOptionsJSON {
+          modules = scope.modules or (throw "A scope requires either optionsJSON or module!");
+          specialArgs = scope.specialArgs or { };
+        });
+      }) scopes;
     in
     runCommand "search-meta"
       {


### PR DESCRIPTION
This was probably used to filter options before ixx was a thing but now it is redundant and removing it allows adding pkgs via specialArgs which is required for nixos-hardware