### PR TITLE
Bump chunk size to 500

### DIFF
--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -38,7 +38,7 @@ rec {
         ixx index \
           --index-output $out/index.ixx \
           --meta-output $out/meta \
-          --chunk-size 100 \
+          --chunk-size 500 \
           $configPath
       '';
 


### PR DESCRIPTION
Right now chunks are usually 50kb to 80kb big and for search.nuschtos.de we already have 380 files