### PR TITLE
wrapper: make mkSearch overrideable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
 
           packages = rec {
             nuscht-search = pkgs.callPackage ./nix/frontend.nix { };
-            inherit (pkgs.callPackages ./nix/wrapper.nix { inherit nuscht-search ixxPkgs; }) mkOptionsJSON mkSearchJSON mkSearch mkMultiSearch;
+            inherit (pkgs.callPackages ./nix/wrapper.nix { inherit ixxPkgs nuscht-search; }) mkOptionsJSON mkSearchJSON mkSearch mkMultiSearch;
             default = nuscht-search;
           };
         }


### PR DESCRIPTION
```
nix-repl> (packages.x86_64-linux.mkSearch { modules = [ inputs.nixpkgs.nixosModules ]; urlPrefix = "https://github.com/NuschtOS/nixos-modules/blob/main/"; })
.override.__functionArgs
{
  baseHref = true;
  title = true;
}
```

```
nix-repl> (packages.x86_64-linux.mkMultiSearch { scopes = [ { modules = [ inputs.nixpkgs.nixosModules ]; urlPrefix = "https://github.com/NuschtOS/nixos-modul
es/blob/main/"; } ]; }).override.__functionArgs
{
  baseHref = true;
  runCommand = false;
  scopes = false;
  title = true;
  xorg = false;
}

```