### PR TITLE
Fix pnpm deps hash in nix/frontent.nix

### DIFF
--- a/nix/frontend.nix
+++ b/nix/frontend.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-asIqRhxlbBLUgDSftUNFrHJmGV9gE0b7JIKfor0ZCx0=";
+    hash = "sha256-ijkw0pIS/YNLK01Ne5Y3hBMWHdypeTC6HBEVrfaG2vE=";
   };
 
   nativeBuildInputs = [ nodejs pnpm.configHook ];


### PR DESCRIPTION
```
┃ error: build of '/nix/store/8g85042yyrjdj7kkwxal1z6zlpim9waa-nuscht-search-pnpm-deps.drv' on 'ssh://glepage@build-box.nix-community.org' failed: hash mismatch in fixed-output deri…
┃          specified: sha256-asIqRhxlbBLUgDSftUNFrHJmGV9gE0b7JIKfor0ZCx0=
┃             got:    sha256-ijkw0pIS/YNLK01Ne5Y3hBMWHdypeTC6HBEVrfaG2vE=
```
