### PR TITLE
fix: fixx_bg.wasm missing in derivation

### DIFF
--- a/nix/frontend.nix
+++ b/nix/frontend.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
     mkdir -p $out
-    cp -r ./dist/browser/* $out/
+    cp -rL ./dist/browser/* $out/
     runHook postInstall
   '';
 })


### PR DESCRIPTION
`cp -r` copies the symlinks directly instead of resolving them, since `fixx_bg.wasm` is a symlink, this creates an invalid output. Instead use `cp -rL` which copies the contents of the symlink adding `fixx_bg.wasm` to the output folder.

Before patch:

```console
$ ls -l result/fixx_bg.wasm
lrwxrwxrwx 10 root root 54 Jan  1  1970 result/fixx_bg.wasm -> /build/source/node_modules/@nuschtos/fixx/fixx_bg.wasm
```

After patch:

```console
$ ls -l result/fixx_bg.wasm
-r--r--r-- 3 root root 82915 Jan  1  1970 result/fixx_bg.wasm
```