### PR TITLE
fix(frontend.nix): set pnpm fetcherVersion to a int

### DIFF
--- a/nix/frontend.nix
+++ b/nix/frontend.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = "2";
+    fetcherVersion = 2;
     hash = "sha256-GXP46VvvUJHfOwszTDEf0trtz4sCNldb0jd/AE3+G30=";
   };
 


### PR DESCRIPTION
fixes "error: pnpm.fetchDeps `fetcherVersion` is not set to a supported value (1, 2)"