### PR TITLE
fix pnpm build error on zfs

### DIFF
--- a/nix/frontend.nix
+++ b/nix/frontend.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 2;
+    pnpmInstallFlags = [ "--package-import-method=hardlink" ]; # Fixes 
     hash = "sha256-Yj3y9veN3DpzjND1wr9dXilXAJfEHtCq8aQfeuRix0Y=";
   };
 


### PR DESCRIPTION
I'm on ZFS and I'm running into this issue here: https://github.com/community-scripts/ProxmoxVE/issues/7192

```bash
╰─➤  nix build .#docs-options -Lv                                                                                                              1 ↵
warning: Git tree '/home/lhebendanz/Projects/clan-core' is dirty
these 2 derivations will be built:
  /nix/store/dq3ilkyrn22azhqc824fx1nqkkgisxfg-nuscht-search-0.0.0.drv
  /nix/store/2dxx47a7aqk4vm3zind0q3mk9a1ffwad-clan-documentation.drv
building '/nix/store/dq3ilkyrn22azhqc824fx1nqkkgisxfg-nuscht-search-0.0.0.drv'...
nuscht-search> Running phase: unpackPhase
nuscht-search> unpacking source archive /nix/store/wn2mzpyvn5w40gm44ygwgzv9g7nvlz5f-source
nuscht-search> source root is source
nuscht-search> Running phase: patchPhase
nuscht-search> Running phase: updateAutotoolsGnuConfigScriptsPhase
nuscht-search> Running phase: configurePhase
nuscht-search> no configure script, doing nothing
nuscht-search> Executing pnpmConfigHook
nuscht-search> Using fetcherVersion: 2
nuscht-search> Configuring pnpm store
nuscht-search> /build /build/source
nuscht-search> /build/source
nuscht-search> Installing dependencies
nuscht-search> Lockfile is up to date, resolution step is skipped
nuscht-search> Progress: resolved 1, reused 0, downloaded 0, added 0
nuscht-search> Packages: +543
nuscht-search> 
nuscht-search> Progress: resolved 1, reused 0, downloaded 0, added 0
nuscht-search> Progress: resolved 543, reused 415, downloaded 0, added 0
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 47
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 68
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 88
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 107
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 128
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 148
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 168
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 187
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 206
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 228
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 248
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 267
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 289
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 308
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 326
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 348
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 368
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 385
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 405
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 425
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 443
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 459
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 481
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 499
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 519
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 535
nuscht-search>  ERR_PNPM_EAGAIN  EAGAIN: resource temporarily unavailable, copyfile '/build/tmp.zge1AQU1DE/v10/files/0c/621af2ed51ba7c02cff5104993b53283fef6b1f6eb0ccd573d95d664cdb25a1d0444bb8cd27609cdd6de3796152cf13b738b00f0c2988fa7f3ae8089d7e29b' -> '/build/source/node_modules/.pnpm/side-channel@1.1.0/node_modules/side-channel_tmp_80/.editorconfig'
nuscht-search> Progress: resolved 543, reused 541, downloaded 0, added 535
nuscht-search> 
nuscht-search> ERROR: pnpm failed to install dependencies
nuscht-search> 
nuscht-search> If you see ERR_PNPM_NO_OFFLINE_TARBALL above this, follow these to fix the issue:
nuscht-search> 1. Set pnpmDeps.hash to "" (empty string)
nuscht-search> 2. Build the derivation and wait for it to fail with a hash mismatch
nuscht-search> 3. Copy the 'got: sha256-' value back into the pnpmDeps.hash field
nuscht-search> 
error: Cannot build '/nix/store/dq3ilkyrn22azhqc824fx1nqkkgisxfg-nuscht-search-0.0.0.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/2qpdcxxf65sk2hir8dp3ngd1x3ms6284-nuscht-search-0.0.0
       Last 25 log lines:
       > Progress: resolved 543, reused 541, downloaded 0, added 267
       > Progress: resolved 543, reused 541, downloaded 0, added 289
       > Progress: resolved 543, reused 541, downloaded 0, added 308
       > Progress: resolved 543, reused 541, downloaded 0, added 326
       > Progress: resolved 543, reused 541, downloaded 0, added 348
       > Progress: resolved 543, reused 541, downloaded 0, added 368
       > Progress: resolved 543, reused 541, downloaded 0, added 385
       > Progress: resolved 543, reused 541, downloaded 0, added 405
       > Progress: resolved 543, reused 541, downloaded 0, added 425
       > Progress: resolved 543, reused 541, downloaded 0, added 443
       > Progress: resolved 543, reused 541, downloaded 0, added 459
       > Progress: resolved 543, reused 541, downloaded 0, added 481
       > Progress: resolved 543, reused 541, downloaded 0, added 499
       > Progress: resolved 543, reused 541, downloaded 0, added 519
       > Progress: resolved 543, reused 541, downloaded 0, added 535
       >  ERR_PNPM_EAGAIN  EAGAIN: resource temporarily unavailable, copyfile '/build/tmp.zge1AQU1DE/v10/files/0c/621af2ed51ba7c02cff5104993b53283fef6b1f6eb0ccd573d95d664cdb25a1d0444bb8cd27609cdd6de3796152cf13b738b00f0c2988fa7f3ae8089d7e29b' -> '/build/source/node_modules/.pnpm/side-channel@1.1.0/node_modules/side-channel_tmp_80/.editorconfig'
       > Progress: resolved 543, reused 541, downloaded 0, added 535
       >
       > ERROR: pnpm failed to install dependencies
       >
       > If you see ERR_PNPM_NO_OFFLINE_TARBALL above this, follow these to fix the issue:
       > 1. Set pnpmDeps.hash to "" (empty string)
       > 2. Build the derivation and wait for it to fail with a hash mismatch
       > 3. Copy the 'got: sha256-' value back into the pnpmDeps.hash field
       >
       For full logs, run:
         nix log /nix/store/dq3ilkyrn22azhqc824fx1nqkkgisxfg-nuscht-search-0.0.0.drv
error: Cannot build '/nix/store/2dxx47a7aqk4vm3zind0q3mk9a1ffwad-clan-documentation.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/0mn1dry94mp9nwynz9463qjnd848inzn-clan-documentation

```