### PR TITLE
Add OpenSearch description

### DIFF
--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>NüschtOS Search</ShortName>
+  <Description>Simple and fast static-page NixOS option and packages search</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/x-icon">favicon.ico</Image>
+  <Url type="text/html" template="./?query={searchTerms}" />
+</OpenSearchDescription>

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="search" type="application/opensearchdescription+xml" title="NüschtOS Search" href="opensearch.xml">
   <meta name="description" content="Simple and fast static-page NixOS option and packages search"/>
 </head>
 


### PR DESCRIPTION
Adds an OpenSearch description file and links it from the document head so browsers can discover the search endpoint more easily. Addresses #154.