### PR TITLE
search: fix results not loading on direct URL entry

### DIFF
--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -13,6 +13,16 @@ test('typing a query returns search option results', async ({ page }) => {
   await expect(page.getByRole('cell', { name: 'Whether to enable the Firefox web browser.', exact: true })).toBeVisible()
 });
 
+test('deeplnk with query returns search option results', async ({ page }) => {
+  await page.goto('/?query=fire*ox*able');
+
+  const searchResultEntry = page.getByRole('link', { name: 'programs.firefox.enable', exact: true });
+  await expect(searchResultEntry).toBeVisible()
+  await searchResultEntry.click()
+
+  await expect(page.getByRole('cell', { name: 'Whether to enable the Firefox web browser.', exact: true })).toBeVisible()
+});
+
 test('typing a query returns search package results', async ({ page }) => {
   await page.goto('/');
 
@@ -29,4 +39,15 @@ test('typing a query returns search package results', async ({ page }) => {
 
   await expect(page.getByRole('cell', { name: 'Web browser built from Firefox source tree', exact: true })).toBeVisible()
 });
+
+test('deeplnk with query returns search package results', async ({ page }) => {
+  await page.goto('/packages?query=fire*ox');
+
+  const searchResultEntry = page.getByRole('link', { name: 'firefox', exact: true });
+  await expect(searchResultEntry).toBeVisible()
+  await searchResultEntry.click()
+
+  await expect(page.getByRole('cell', { name: 'Web browser built from Firefox source tree', exact: true })).toBeVisible()
+});
+
 

--- a/src/app/core/components/search/search.component.ts
+++ b/src/app/core/components/search/search.component.ts
@@ -117,9 +117,6 @@ export class SearchComponent<T> {
     const { query, scope } = getQuery(this.activatedRoute);
     const id = this.scopes.find(s => s.name === scope)?.id ?? -1;
     this.search.setValue({ query: query ?? '', scope: id.toString() })
-
-    this.doSearch(scope === null ? null : Number(scope), query)
-      .subscribe(value => this.results.next(value));
   }
 
   protected ngOnDestroy0(): void {


### PR DESCRIPTION
**Issue:** When visiting the search page with query parameters in the URL (e.g. `/options?scope=nix-darwin&query=services`), the search input and scope selector are correctly populated but no results appear until the user changes one of the inputs on the page.

Currently, `ngAfterViewInit0` does two things:

1. `setValue()`
    
    Triggers `valueChanges` → `formValue` → `doSearch` with the correct numeric scope ID.
2. A direct `doSearch` call
    
    I think this was meant to pass the resolved numeric `id` from the line above, but instead passes `Number(scope)` where `scope` is the scope name string (e.g. `"nix-darwin"`), yielding `NaN`. So the WASM search engine receives an invalid scope ID and returns no results.

Both subscribe to `ready$` (the WASM index loading observable), so whichever completes last overwrites `this.results`. The direct call clobbers correct results with an empty array.

> [!NOTE]
> Even if the parameter of the direct call were fixed to use `id`, I think it would still be redundant. `setValue()` on the preceding line already triggers the full reactive pipeline, and the `queryParams` subscription in `ngOnInit0` independently triggers it on initial load.

**Solution:** Delete the direct `doSearch` call entirely.

I'm not familiar with the codebase, so I hope I'm not missing anything. But it addresses the issue in my testing.

**Related:** #154 (without my fix, direct searches that are limited to a specific scope will not load correctly)